### PR TITLE
validating: reject empty string as valid RootFolder

### DIFF
--- a/Blasphemous.Modding.Installer/PageComponents/Validators/StandardValidator.cs
+++ b/Blasphemous.Modding.Installer/PageComponents/Validators/StandardValidator.cs
@@ -193,6 +193,9 @@ internal class StandardValidator : IValidator
     {
         get
         {
+            if (string.IsNullOrEmpty(_settings.RootFolder))
+                return false;
+
             string path = Path.Combine(_settings.RootFolder, _exeName);
             return File.Exists(path);
         }


### PR DESCRIPTION
- Fixes a bug that would count "" as a valid root path if Blasphemous.exe was in the same folder as the installer