### PR TITLE
ui: dynamic grouper height

### DIFF
--- a/Blasphemous.Modding.Installer/UIHandler.cs
+++ b/Blasphemous.Modding.Installer/UIHandler.cs
@@ -125,6 +125,7 @@ public partial class UIHandler : BasaltForm
 
         // Handle UI for grouping
         _left_all.Visible = validated;
+        _left_all.Height = currentPage.Grouper.CanEnable ? 110 : 65;
         _left_all_install.Visible = currentPage.Grouper.CanInstall;
         _left_all_uninstall.Visible = currentPage.Grouper.CanInstall;
         _left_all_enable.Visible = currentPage.Grouper.CanEnable;


### PR DESCRIPTION
- Hide extra space on skin pages where the enable/disable buttons are hidden