### PR TITLE
core: catch HTTP 429 errors

### DIFF
--- a/Blasphemous.Modding.Installer/Core.cs
+++ b/Blasphemous.Modding.Installer/Core.cs
@@ -207,4 +207,6 @@ static class Core
 
     public static string InstallerFolder { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "BlasModInstaller");
     public static string CacheFolder { get; } = Path.Combine(InstallerFolder, "cache");
+
+    public const int HTTP_TIMEOUT = 2000;
 }

--- a/Blasphemous.Modding.Installer/Extensions/WebExtensions.cs
+++ b/Blasphemous.Modding.Installer/Extensions/WebExtensions.cs
@@ -1,12 +1,25 @@
-﻿
+﻿using Basalt.Framework.Logging;
+
 namespace Blasphemous.Modding.Installer.Extensions;
 
 public static class WebExtensions
 {
-    public static async Task DownloadFileAsync(this HttpClient client, Uri uri, string fileName)
+    public static async Task DownloadFileAsync(this HttpClient client, Uri uri, string fileName, int timeout)
     {
-        using var stream = await client.GetStreamAsync(uri);
-        using var filestream = new FileStream(fileName, FileMode.CreateNew);
-        await stream.CopyToAsync(filestream);
+        try
+        {
+            using var stream = await client.GetStreamAsync(uri);
+            using var filestream = new FileStream(fileName, FileMode.CreateNew);
+            await stream.CopyToAsync(filestream);
+        }
+        catch (HttpRequestException ex)
+        {
+            if (ex.StatusCode != System.Net.HttpStatusCode.TooManyRequests)
+                throw;
+
+            Logger.Warn($"HTTP 429 error when downloading {uri}.  Retrying...");
+            await Task.Delay(timeout);
+            await DownloadFileAsync(client, uri, fileName, timeout + Core.HTTP_TIMEOUT);
+        }
     }
 }

--- a/Blasphemous.Modding.Installer/Mods/Mod.cs
+++ b/Blasphemous.Modding.Installer/Mods/Mod.cs
@@ -126,7 +126,7 @@ internal class Mod
         _downloading = true;
         _ui.ShowDownloadingStatus();
 
-        await client.DownloadFileAsync(new Uri(Data.latestDownloadURL), zipCache);
+        await client.DownloadFileAsync(new Uri(Data.latestDownloadURL), zipCache, Core.HTTP_TIMEOUT);
 
         _downloading = false;
     }

--- a/Blasphemous.Modding.Installer/PageComponents/Loaders/SkinLoader.cs
+++ b/Blasphemous.Modding.Installer/PageComponents/Loaders/SkinLoader.cs
@@ -83,7 +83,7 @@ internal class SkinLoader : ILoader
 
         foreach (var item in contents)
         {
-            Skin skin = await LoadSkin(item, client);
+            Skin skin = await LoadSkin(item, client, Core.HTTP_TIMEOUT);
             newSkins.Add(skin);
         }
 
@@ -95,7 +95,7 @@ internal class SkinLoader : ILoader
         _lister.RefreshList();
     }
 
-    private async Task<Skin> LoadSkin(RepositoryContent item, HttpClient client)
+    private async Task<Skin> LoadSkin(RepositoryContent item, HttpClient client, int timeout)
     {
         try
         {
@@ -117,8 +117,8 @@ internal class SkinLoader : ILoader
                 throw;
 
             Logger.Warn($"HTTP 429 error with skin {item.Name}.  Retrying...");
-            await Task.Delay(2000);
-            return await LoadSkin(item, client);
+            await Task.Delay(timeout);
+            return await LoadSkin(item, client, timeout + Core.HTTP_TIMEOUT);
         }
     }
 

--- a/Blasphemous.Modding.Installer/PageComponents/Validators/StandardValidator.cs
+++ b/Blasphemous.Modding.Installer/PageComponents/Validators/StandardValidator.cs
@@ -180,7 +180,7 @@ internal class StandardValidator : IValidator
         {
             Logger.Warn("Downloading modding tools from web");
             using var client = new HttpClient();
-            await client.DownloadFileAsync(new Uri(_remoteDownloadPath), toolsCache);
+            await client.DownloadFileAsync(new Uri(_remoteDownloadPath), toolsCache, Core.HTTP_TIMEOUT);
         }
 
         // Extract data in cache to game folder

--- a/Blasphemous.Modding.Installer/Prompts/SkinPreviewPrompt.cs
+++ b/Blasphemous.Modding.Installer/Prompts/SkinPreviewPrompt.cs
@@ -75,6 +75,6 @@ internal partial class SkinPreviewPrompt : Form
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
         using var client = new HttpClient();
-        await client.DownloadFileAsync(new Uri(url), path);
+        await client.DownloadFileAsync(new Uri(url), path, Core.HTTP_TIMEOUT);
     }
 }

--- a/Blasphemous.Modding.Installer/Skins/Skin.cs
+++ b/Blasphemous.Modding.Installer/Skins/Skin.cs
@@ -126,8 +126,8 @@ internal class Skin
         _downloading = true;
         _ui.ShowDownloadingStatus();
 
-        await client.DownloadFileAsync(new Uri(InfoURL), infoCache);
-        await client.DownloadFileAsync(new Uri(TextureURL), textureCache);
+        await client.DownloadFileAsync(new Uri(InfoURL), infoCache, Core.HTTP_TIMEOUT);
+        await client.DownloadFileAsync(new Uri(TextureURL), textureCache, Core.HTTP_TIMEOUT);
 
         _downloading = false;
     }
@@ -152,7 +152,7 @@ internal class Skin
         if (!ExistsInCache("info.txt", out string infoCache))
         {
             Logger.Warn($"Downloading skin info ({Data.id}) from web");
-            await client.DownloadFileAsync(new Uri(InfoURL), infoCache);
+            await client.DownloadFileAsync(new Uri(InfoURL), infoCache, Core.HTTP_TIMEOUT);
         }
 
         // Download all textures to cache
@@ -162,7 +162,7 @@ internal class Skin
                 continue;
 
             Logger.Warn($"Downloading skin texture ({Data.id}/{file.Name}) from web");
-            await client.DownloadFileAsync(new Uri(file.DownloadUrl), textureCache);
+            await client.DownloadFileAsync(new Uri(file.DownloadUrl), textureCache, Core.HTTP_TIMEOUT);
         }
 
         string installPath = PathToSkinFolder;


### PR DESCRIPTION
When looping over multiple API requests, use a try-catch block to repeat the request with a higher timeout