### PR TITLE
Adding Weapon Events Framwork and Better Weapon Swap to the list of B2 mods

### DIFF
--- a/BlasphemousIIMods.json
+++ b/BlasphemousIIMods.json
@@ -150,5 +150,15 @@
     "GithubRepo": "BlasII.Framework.WeaponEvents",
     "PluginFile": "WeaponEventsFramework.dll",
     "Dependencies": [ "Modding API" ]
+  },
+  {
+    "Name": "Better Weapon Swap",
+    "Author": "salamint",
+    "Description": "Improves weapon swapping by keeping the charge of the different powers for each weapon",
+    "InitialReleaseDate": "2025-12-6",
+    "GithubAuthor": "salamint",
+    "GithubRepo": "BlasII.BetterWeaponSwap",
+    "PluginFile": "BetterWeaponSwap.dll",
+    "Dependencies": [ "Modding API", "Weapon Events Framework" ]
   }
 ]


### PR DESCRIPTION
This pull request adds metadata for the [Weapon Events Framework](https://github.com/salamint/BlasII.Framework.WeaponEvents) and [Better Weapon Swap](https://github.com/salamint/BlasII.BetterWeaponSwap) mods to the `BlasphemousIIMods.json` file.

This allows people to download and install those mods from the mod installer.